### PR TITLE
Set application extension api only on iOS target to allow using Awesome in widgets

### DIFF
--- a/AwesomeEnum.xcodeproj/project.pbxproj
+++ b/AwesomeEnum.xcodeproj/project.pbxproj
@@ -659,6 +659,7 @@
 		15116D2120761BAD00BC08D3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
@@ -684,6 +685,7 @@
 		15116D2220761BAD00BC08D3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
This pr removes warning when using carthage:

![Screenshot 2019-07-31 at 12 18 17](https://user-images.githubusercontent.com/7826664/62204493-8a167900-b38d-11e9-81ea-d94a43b7d0af.png)
