### PR TITLE
Update Awesome/AwesomePro, make enums CaseIterable and add withKey fu…

### DIFF
--- a/Classes/Enums/Awesome.swift
+++ b/Classes/Enums/Awesome.swift
@@ -469,7 +469,7 @@ public struct Awesome {
         case youtubeSquare = "\u{f431}"
         case zhihu = "\u{f63f}"
 
-        static func withKey(_ label: String) -> Brand? {
+        public static func withKey(_ label: String) -> Brand? {
             return self.allCases.first { label == "\($0)" }
         }
 
@@ -1481,7 +1481,7 @@ public struct Awesome {
         case yenSign = "\u{f157}"
         case yinYang = "\u{f6ad}"
 
-        static func withKey(_ label: String) -> Solid? {
+        public static func withKey(_ label: String) -> Solid? {
             return self.allCases.first { label == "\($0)" }
         }
 
@@ -1643,7 +1643,7 @@ public struct Awesome {
         case windowMinimize = "\u{f2d1}"
         case windowRestore = "\u{f2d2}"
 
-        static func withKey(_ label: String) -> Regular? {
+        public static func withKey(_ label: String) -> Regular? {
             return self.allCases.first { label == "\($0)" }
         }
 

--- a/Classes/Enums/Awesome.swift
+++ b/Classes/Enums/Awesome.swift
@@ -11,7 +11,7 @@ import Foundation
 
 public struct Awesome {
 
-    public enum Brand: String, Amazing {
+    public enum Brand: String, Amazing, CaseIterable {
         case fa500px = "\u{f26e}"
         case accessibleIcon = "\u{f368}"
         case accusoft = "\u{f369}"
@@ -469,12 +469,16 @@ public struct Awesome {
         case youtubeSquare = "\u{f431}"
         case zhihu = "\u{f63f}"
 
+        static func withKey(_ label: String) -> Brand? {
+            return self.allCases.first { label == "\($0)" }
+        }
+
         public var fontType: AwesomeFont {
             return Awesome.Font.brand
         }
     }
 
-    public enum Solid: String, Amazing {
+    public enum Solid: String, Amazing, CaseIterable {
         case ad = "\u{f641}"
         case addressBook = "\u{f2b9}"
         case addressCard = "\u{f2bb}"
@@ -1477,12 +1481,16 @@ public struct Awesome {
         case yenSign = "\u{f157}"
         case yinYang = "\u{f6ad}"
 
+        static func withKey(_ label: String) -> Solid? {
+            return self.allCases.first { label == "\($0)" }
+        }
+
         public var fontType: AwesomeFont {
             return Awesome.Font.solid
         }
     }
 
-    public enum Regular: String, Amazing {
+    public enum Regular: String, Amazing, CaseIterable {
         case addressBook = "\u{f2b9}"
         case addressCard = "\u{f2bb}"
         case angry = "\u{f556}"
@@ -1634,6 +1642,10 @@ public struct Awesome {
         case windowMaximize = "\u{f2d0}"
         case windowMinimize = "\u{f2d1}"
         case windowRestore = "\u{f2d2}"
+
+        static func withKey(_ label: String) -> Regular? {
+            return self.allCases.first { label == "\($0)" }
+        }
 
         public var fontType: AwesomeFont {
             return Awesome.Font.regular

--- a/Classes/Enums/AwesomePro.swift
+++ b/Classes/Enums/AwesomePro.swift
@@ -10,7 +10,7 @@
 import Foundation
 
 public struct AwesomePro {
-    
+
     public enum Regular: String, Amazing, CaseIterable {
         case abacus = "\u{f640}"
         case acorn = "\u{f6ae}"
@@ -1865,7 +1865,7 @@ public struct AwesomePro {
         case yenSign = "\u{f157}"
         case yinYang = "\u{f6ad}"
 
-        static func withKey(_ label: String) -> Regular? {
+        public static func withKey(_ label: String) -> Regular? {
             return self.allCases.first { label == "\($0)" }
         }
 
@@ -2332,7 +2332,7 @@ public struct AwesomePro {
         case youtubeSquare = "\u{f431}"
         case zhihu = "\u{f63f}"
 
-        static func withKey(_ label: String) -> Brand? {
+        public static func withKey(_ label: String) -> Brand? {
             return self.allCases.first { label == "\($0)" }
         }
 
@@ -4195,7 +4195,7 @@ public struct AwesomePro {
         case yenSign = "\u{f157}"
         case yinYang = "\u{f6ad}"
 
-        static func withKey(_ label: String) -> Solid? {
+        public static func withKey(_ label: String) -> Solid? {
             return self.allCases.first { label == "\($0)" }
         }
 
@@ -6058,7 +6058,7 @@ public struct AwesomePro {
         case yenSign = "\u{f157}"
         case yinYang = "\u{f6ad}"
 
-        static func withKey(_ label: String) -> Light? {
+        public static func withKey(_ label: String) -> Light? {
             return self.allCases.first { label == "\($0)" }
         }
 
@@ -7921,7 +7921,7 @@ public struct AwesomePro {
         case yenSign = "\u{f157}"
         case yinYang = "\u{f6ad}"
 
-        static func withKey(_ label: String) -> Duotone? {
+        public static func withKey(_ label: String) -> Duotone? {
             return self.allCases.first { label == "\($0)" }
         }
 

--- a/Classes/Enums/AwesomePro.swift
+++ b/Classes/Enums/AwesomePro.swift
@@ -10,8 +10,8 @@
 import Foundation
 
 public struct AwesomePro {
-
-    public enum Regular: String, Amazing {
+    
+    public enum Regular: String, Amazing, CaseIterable {
         case abacus = "\u{f640}"
         case acorn = "\u{f6ae}"
         case ad = "\u{f641}"
@@ -1865,12 +1865,16 @@ public struct AwesomePro {
         case yenSign = "\u{f157}"
         case yinYang = "\u{f6ad}"
 
+        static func withKey(_ label: String) -> Regular? {
+            return self.allCases.first { label == "\($0)" }
+        }
+
         public var fontType: AwesomeFont {
             return AwesomePro.Font.regular
         }
     }
 
-    public enum Brand: String, Amazing {
+    public enum Brand: String, Amazing, CaseIterable {
         case fa500px = "\u{f26e}"
         case accessibleIcon = "\u{f368}"
         case accusoft = "\u{f369}"
@@ -2328,12 +2332,16 @@ public struct AwesomePro {
         case youtubeSquare = "\u{f431}"
         case zhihu = "\u{f63f}"
 
+        static func withKey(_ label: String) -> Brand? {
+            return self.allCases.first { label == "\($0)" }
+        }
+
         public var fontType: AwesomeFont {
             return AwesomePro.Font.brand
         }
     }
 
-    public enum Solid: String, Amazing {
+    public enum Solid: String, Amazing, CaseIterable {
         case abacus = "\u{f640}"
         case acorn = "\u{f6ae}"
         case ad = "\u{f641}"
@@ -4186,13 +4194,17 @@ public struct AwesomePro {
         case xRay = "\u{f497}"
         case yenSign = "\u{f157}"
         case yinYang = "\u{f6ad}"
+
+        static func withKey(_ label: String) -> Solid? {
+            return self.allCases.first { label == "\($0)" }
+        }
 
         public var fontType: AwesomeFont {
             return AwesomePro.Font.solid
         }
     }
 
-    public enum Light: String, Amazing {
+    public enum Light: String, Amazing, CaseIterable {
         case abacus = "\u{f640}"
         case acorn = "\u{f6ae}"
         case ad = "\u{f641}"
@@ -6045,13 +6057,17 @@ public struct AwesomePro {
         case xRay = "\u{f497}"
         case yenSign = "\u{f157}"
         case yinYang = "\u{f6ad}"
+
+        static func withKey(_ label: String) -> Light? {
+            return self.allCases.first { label == "\($0)" }
+        }
 
         public var fontType: AwesomeFont {
             return AwesomePro.Font.light
         }
     }
 
-    public enum Duotone: String, Amazing {
+    public enum Duotone: String, Amazing, CaseIterable {
         case abacus = "\u{f640}"
         case acorn = "\u{f6ae}"
         case ad = "\u{f641}"
@@ -7905,9 +7921,12 @@ public struct AwesomePro {
         case yenSign = "\u{f157}"
         case yinYang = "\u{f6ad}"
 
+        static func withKey(_ label: String) -> Duotone? {
+            return self.allCases.first { label == "\($0)" }
+        }
+
         public var fontType: AwesomeFont {
             return AwesomePro.Font.duotone
         }
     }
-
 }


### PR DESCRIPTION
Adding CaseIterable to enums allows us to call them dynamicly with rawValue

`Awesome.Regular(rawValue: "\u{f007}")?.image`
`AwesomePro.Regular(rawValue: "\u{f640}")?.image`

Additionally by adding the static withKey function to the enums, we can call icons by the key value as a string

`Awesome.Regular.withKey("user")?.image`
`AwesomePro.Regular.withKey("bell")?.image`